### PR TITLE
add page tracking to url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,18 @@
 # Bookmark URL
 
-An OpenSeadragon plugin for updating the zoom/pan in the page URL.
+An OpenSeadragon plugin for updating the zoom/pan/page in the page URL.
 
 ## Usage
 
 Create your OpenSeadragon viewer and then:
 
 ```
-viewer.bookmarkUrl();
+viewer.bookmarkUrl({
+	trackPage: true // default is false
+});
 ```
 
-It'll take the viewer to wherever the page's hash parameters point, and it'll update the page URL with hash parameters.
+It'll take the viewer to wherever the page's hash parameters point, and it'll update the page URL with hash parameters. The optional `trackPage` parameter adds the active page of an OSD sequence to the hash parameters.
 
 You can watch for the `bookmark-url-change` event on the viewer to be notified when the URL changes (the `url` property of the event is the new URL).
 

--- a/openseadragon-bookmark-url.js
+++ b/openseadragon-bookmark-url.js
@@ -10,7 +10,7 @@
             throw new Error('OpenSeadragon is missing.');
         }
     }
-    
+
     // ----------
     $.Viewer.prototype.bookmarkUrl = function({trackPage = false} = {}) {
         var self = this;
@@ -92,13 +92,12 @@
         } else {
             useParams(params);
         }
-        
+
         this.addHandler('zoom', updateUrl);
         this.addHandler('pan', updateUrl);
         if (trackPage) {
             this.addHandler('page', updateUrl);
         }
-
 
         // Note that out own replaceState calls don't trigger hashchange events, so this is only if
         // the user has modified the URL (by pasting one in, for instance).

--- a/openseadragon-bookmark-url.js
+++ b/openseadragon-bookmark-url.js
@@ -12,7 +12,10 @@
     }
 
     // ----------
-    $.Viewer.prototype.bookmarkUrl = function({trackPage = false} = {}) {
+    $.Viewer.prototype.bookmarkUrl = function(options) {
+        options = options || {};
+        var trackPage = options.trackPage || false;
+
         var self = this;
 
         var updateTimeout;
@@ -61,14 +64,6 @@
             var zoom = self.viewport.getZoom();
             var pan = self.viewport.getCenter();
             var page = self.currentPage();
-
-            if (params.zoom !== undefined && params.zoom !== zoom) {
-                self.viewport.zoomTo(params.zoom, null, true);
-            }
-
-            if (params.x !== undefined && params.y !== undefined && (params.x !== pan.x || params.y !== pan.y)) {
-                self.viewport.panTo(new $.Point(params.x, params.y), true);
-            }
             
             if (trackPage && params.page !== undefined && params.page !== page) {
                 self.goToPage(params.page);
@@ -80,6 +75,13 @@
                         self.viewport.panTo(new $.Point(params.x, params.y), true);
                     }
                 });
+            } else {
+                if (params.zoom !== undefined && params.zoom !== zoom) {
+                    self.viewport.zoomTo(params.zoom, null, true);
+                }
+                if (params.x !== undefined && params.y !== undefined && (params.x !== pan.x || params.y !== pan.y)) {
+                    self.viewport.panTo(new $.Point(params.x, params.y), true);
+                }
             }
         };
 


### PR DESCRIPTION
optional parameter for enabling tracking of the OSD sequence page in the URL, defaults to false:
`viewer.bookmarkUrl({trackPage: true});`