### PR TITLE
revised updateUrl function to include querystring in url

### DIFF
--- a/openseadragon-bookmark-url.js
+++ b/openseadragon-bookmark-url.js
@@ -48,7 +48,8 @@
                 var pan = self.viewport.getCenter();
                 var page = self.currentPage();
                 var oldUrl = location.pathname + location.hash;
-                var url = location.pathname + '#zoom=' + zoom + '&x=' + pan.x + '&y=' + pan.y;
+                var search = location.search;
+                var url = location.pathname + search + '#zoom=' + zoom + '&x=' + pan.x + '&y=' + pan.y;
                 if (trackPage) {
                     url = url + '&page=' + page;
                 }


### PR DESCRIPTION
As per issue #1, preserve query string when updating url. Comes in handy when using IIPImage or similar systems that serve images via query string (e.g. iipsrv.fcgi?FIF=PIA03883.pyr.tif&JTL=1,3).